### PR TITLE
4septiembre

### DIFF
--- a/public/css/carrito-sin-sesion.css
+++ b/public/css/carrito-sin-sesion.css
@@ -316,12 +316,9 @@ body.carrito-sin-sesion {
 .carrito-header {
     display: flex;
     align-items: center;
-    justify-content: center;
+    justify-content: start;
     gap: 16px;
-    background-color: var(--white-color);
-    padding: 20px 24px;
     border-radius: var(--border-radius-lg);
-    box-shadow: var(--shadow-sm);
 }
 
 .carrito-logo {

--- a/public/css/producto-descripcion.css
+++ b/public/css/producto-descripcion.css
@@ -28,7 +28,7 @@ body {
   display: flex;
   flex-direction: column;
   padding: 24px;
-  max-width: 1200px;
+  max-width: 1400px;
   margin: 0 auto;
   gap: 28px;
 }

--- a/views/carrito/ver-sin-sesion.php
+++ b/views/carrito/ver-sin-sesion.php
@@ -124,7 +124,7 @@ if (isset($_SESSION['carrito'])) {
             <!-- Columna derecha: Header del carrito y resumen -->
             <div class="right-column">
                 <div class="carrito-header">
-                    <h1 class="carrito-title">Carro de compra</h1>
+                    <h1 class="carrito-title">Resumen de la compra</h1>
                 </div>
 
                 <!-- Contenedor principal del carrito que se actualizará -->

--- a/views/home/index.php
+++ b/views/home/index.php
@@ -154,20 +154,21 @@ if (!isset($categorias)) {
         <div class="features-grid">
           <div class="feature-box">
             <i class="fa-solid fa-shield-halved"></i>
-            <h3>Calidad Garantizada</h3>
-            <p>Seleccionamos los mejores componentes y periféricos de marcas líderes para asegurar tu satisfacción y rendimiento.</p>
+            <h3>Calidad Premium</h3>
+            <p>Garantizamos productos seleccionados bajo estrictos estándares, diseñados para ofrecerte el máximo rendimiento y una experiencia de compra superior.</p>
           </div>
           <div class="feature-box">
             <i class="fa-solid fa-headset"></i>
-            <h3>Soporte Técnico Experto</h3>
-            <p>Nuestro equipo está listo para ayudarte con cualquier consulta, desde la compatibilidad de piezas hasta la configuración de tu equipo.</p>
+            <h3>Soporte Postventa</h3>
+            <p>Nuestro equipo especializado te brinda asistencia continua después de tu compra, resolviendo dudas y asegurando el mejor desempeño de tus equipos.</p>
           </div>
           <div class="feature-box">
             <i class="fa-solid fa-truck-fast"></i>
             <h3>Envíos a Nivel Nacional</h3>
-            <p>Recibe tus productos de forma rápida y segura en la puerta de tu casa, sin importar en qué parte del país te encuentres.</p>
+            <p>Realizamos entregas rápidas y seguras, con un tiempo de envío de hasta 24 horas en Lima y de 1 a 2 días en provincias, asegurando puntualidad y confianza en cada pedido.</p>
           </div>
         </div>
+
       </div>
     </section>
   </main>

--- a/views/producto/descripcion.php
+++ b/views/producto/descripcion.php
@@ -131,37 +131,72 @@ function producto_imagen_url($producto, $idx = 0)
 
             <div class="product-short-description">
                 <h2>Especificaciones Clave:</h2>
-<!-- Mostramos las especificaciones como una lista -->
-<ul class="specs-list-short">
-    <?php if (!empty($producto['especificaciones_array']) && is_array($producto['especificaciones_array'])): ?>
-        <?php 
-        // Tomamos solo las primeras 5 especificaciones para no saturar el espacio
-        $especificacionesMostradas = array_slice($producto['especificaciones_array'], 0, 5); 
-        ?>
-        <?php foreach ($especificacionesMostradas as $spec): ?>
-            <li><?= htmlspecialchars($spec) ?></li>
-        <?php endforeach; ?>
-    <?php else: ?>
-        <li>No hay especificaciones disponibles.</li>
-    <?php endif; ?>
-</ul>
-<a href="#descripcion-section" class="read-more-link">Ver descripción completa</a>
+                <!-- Mostramos las especificaciones como una lista -->
+                <ul class="specs-list-short">
+                    <?php if (!empty($producto['especificaciones_array']) && is_array($producto['especificaciones_array'])): ?>
+                        <?php
+                        // Tomamos solo las primeras 5 especificaciones para no saturar el espacio
+                        $especificacionesMostradas = array_slice($producto['especificaciones_array'], 0, 5);
+                        ?>
+                        <?php foreach ($especificacionesMostradas as $spec): ?>
+                            <li><?= htmlspecialchars($spec) ?></li>
+                        <?php endforeach; ?>
+                    <?php else: ?>
+                        <li>No hay especificaciones disponibles.</li>
+                    <?php endif; ?>
+                </ul>
+                <a href="#descripcion-section" class="read-more-link">Ver descripción completa</a>
 
 
                 <div class="info-boxes">
-                    <div class="info-box">
-                        <img src="<?= url('images/delivery_icon.png') ?>" alt="Envíos">
-                        <span>Envíos a todo el Perú</span>
-                    </div>
-                    <div class="info-box">
-                        <img src="<?= url('images/warranty_icon.png') ?>" alt="Garantía">
-                        <span>Garantía en tus pedidos</span>
-                    </div>
-                    <div class="info-box">
-                        <img src="<?= url('images/secure_payment_icon.png') ?>" alt="Pagos Seguros">
-                        <span>Pagos 100% seguros</span>
-                    </div>
-                </div>
+  <div class="info-box">
+    <i class="fa-solid fa-truck"></i>
+    <span>Envíos rápidos a todo el Perú</span>
+  </div>
+  <div class="info-box">
+    <i class="fa-solid fa-certificate"></i>
+    <span>Garantía Bytebox en todos tus pedidos</span>
+  </div>
+  <div class="info-box">
+    <i class="fa-solid fa-circle-check"></i>
+    <span>Pagos seguros y protegidos siempre</span>
+  </div>
+</div>
+<style>
+  .info-boxes {
+    display: flex;
+    justify-content: space-between; /* distribuye de forma más pareja */
+    gap: 0.8rem; /* menor separación entre bloques */
+    width: 100%;
+  }
+
+  .info-box {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    flex: 1; /* cada caja ocupa el mismo ancho */
+  }
+
+  .info-box i {
+    font-size: 1.2rem; /* un poco más pequeño */
+    color: var(--primary-color);
+    border: 2px solid var(--primary-color);
+    border-radius: 50%;
+    padding: 8px; /* más compacto */
+    margin-right: 8px; /* espacio mínimo entre ícono y texto */
+    margin-bottom: 0; /* quitamos margen inferior */
+  }
+
+  .info-box span {
+    text-align: left;   /* alinea a la izquierda */
+    white-space: nowrap; /* evita salto de línea */
+    font-size: 0.9rem;
+    font-weight: 500;
+    color: #333;
+  }
+</style>
+
+
             </div>
 
             <div class="product-details">


### PR DESCRIPTION
Cambiar los textos del home en la parte de Soporte
En los iconos de Envíos gratis, deben ser de turquesa y decir "garantia bytebox en todos tus pedidos".
Cambiar el texto "Resumen de la compra" en vez de "Carrito de Compra" en el carrito.